### PR TITLE
chore(deps): bump ksapi to 1.95.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "mcp>=1.2",
     "httpx>=0.27",
     "pydantic>=2.6",
-    "ksapi>=0.1.0",
+    "ksapi>=1.95.4",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -306,7 +306,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
-    { name = "ksapi", specifier = ">=0.1.0" },
+    { name = "ksapi", specifier = ">=1.95.4" },
     { name = "mcp", specifier = ">=1.2" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1" },
@@ -319,7 +319,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ksapi"
-version = "1.72.4"
+version = "1.95.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -327,9 +327,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/f3/c2d44a7358eae17960ec3ad2ebc86f3ed0079aa8f861f8821093d1942b11/ksapi-1.72.4.tar.gz", hash = "sha256:ac327f2a0b747b347e391a4bdfcec50d9fdf1a13f364927c08d92b386ce6f9b9", size = 180925, upload-time = "2026-04-14T06:24:35.311Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/b9/8039361737e8e7aaedda2a4987ac9926be181f63e65b49b847aa3cca6e6b/ksapi-1.95.4.tar.gz", hash = "sha256:9865c16f0529d7ab5b88cb17d64f6acb3b78cd8879c7d26a0eb8fbce4e89ed1c", size = 237301, upload-time = "2026-06-08T06:35:43.891Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/a8/6859af11386f840c2f5f235eba87348913cc31f0e4fcc8afb6e63fe3a473/ksapi-1.72.4-py3-none-any.whl", hash = "sha256:f89ff83f86cd38541e104c5f227897ec85df7d9ad09c7bf3773a5a537e85529c", size = 364850, upload-time = "2026-04-14T06:24:33.843Z" },
+    { url = "https://files.pythonhosted.org/packages/be/31/9ca9e96519a05df635cbebf42a503651cc9a1b99269ce792d29df23208ba/ksapi-1.95.4-py3-none-any.whl", hash = "sha256:51a70614d18cfa6884e24e50d9fffe1fc933051944d6ce90a25f0886ef225825", size = 471812, upload-time = "2026-06-08T06:35:42.43Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Auto-generated after a Knowledge Stack SDK release.

- Upstream tag: `v1.95.4`
- Updates `ksapi` pin in `pyproject.toml` to `>=1.95.4`
- Relocks `uv.lock`

CI will validate the bump doesn't break the MCP server's tests.