### PR TITLE
chore(deps): bump ksapi to 1.123.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "mcp>=1.2",
     "httpx>=0.27",
     "pydantic>=2.6",
-    "ksapi>=0.1.0",
+    "ksapi>=1.123.1",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -306,7 +306,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
-    { name = "ksapi", specifier = ">=0.1.0" },
+    { name = "ksapi", specifier = ">=1.123.1" },
     { name = "mcp", specifier = ">=1.2" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1" },
@@ -319,7 +319,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "ksapi"
-version = "1.72.4"
+version = "1.123.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
@@ -327,9 +327,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/f3/c2d44a7358eae17960ec3ad2ebc86f3ed0079aa8f861f8821093d1942b11/ksapi-1.72.4.tar.gz", hash = "sha256:ac327f2a0b747b347e391a4bdfcec50d9fdf1a13f364927c08d92b386ce6f9b9", size = 180925, upload-time = "2026-04-14T06:24:35.311Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/bc/c824151c8e09ebf52feb5c88f00968a4d8af0843812bdd61c5c1b99af7fc/ksapi-1.123.1.tar.gz", hash = "sha256:a1c28d170f002bbcfb0586d8eebdde51b8ba11dd3968399c26ad552a455ed397", size = 304480, upload-time = "2026-07-06T12:43:05.352Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/a8/6859af11386f840c2f5f235eba87348913cc31f0e4fcc8afb6e63fe3a473/ksapi-1.72.4-py3-none-any.whl", hash = "sha256:f89ff83f86cd38541e104c5f227897ec85df7d9ad09c7bf3773a5a537e85529c", size = 364850, upload-time = "2026-04-14T06:24:33.843Z" },
+    { url = "https://files.pythonhosted.org/packages/12/e5/edc83078a6e8e3ebc8e07dda09194ef9f659c86fed08f933ac4bc422691c/ksapi-1.123.1-py3-none-any.whl", hash = "sha256:90c2d1c123cff7af8cabfdc01319f0dd1a8c9d9ff2788371c01bbbf39b0ba576", size = 631977, upload-time = "2026-07-06T12:43:04.046Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Auto-generated after a Knowledge Stack SDK release.

- Upstream tag: `v1.123.1`
- Updates `ksapi` pin in `pyproject.toml` to `>=1.123.1`
- Relocks `uv.lock`

CI will validate the bump doesn't break the MCP server's tests.